### PR TITLE
remove favicon from jekyll

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,9 @@
 <html lang="en-US">
   <head>
     <meta charset="UTF-8">
-
+<link rel="icon" type="image" href="favicon.png">
 <!-- Begin Jekyll SEO tag v2.7.1 -->
 <title>gemsvidø’s projects</title>
-<link rel="icon" type="image" href="favicon.png">
 <meta name="generator" content="Jekyll v3.9.0" />
 <meta property="og:title" content="gemsvidø’s projects" />
 <meta property="og:locale" content="en_US" />


### PR DESCRIPTION
It turns out that jekyll doesn't let the site read the favicon source, so I moved it

(add me)
it might be easier to give me write acess if you want to, though